### PR TITLE
Wrong port number in cypher configuration?

### DIFF
--- a/neo4j/sesion7.ipynb
+++ b/neo4j/sesion7.ipynb
@@ -88,7 +88,7 @@
    "outputs": [],
    "source": [
     "%load_ext cypher\n",
-    "%config CypherMagic.uri='http://neo4j:root@127.0.0.1:3306/db/data'"
+    "%config CypherMagic.uri='http://neo4j:root@127.0.0.1:7474/db/data'"
    ]
   },
   {


### PR DESCRIPTION
According to the rest of the document, shouldn't be 7474 the used port instead of 3306? Otherwise I get a connection error:

ConnectionError: HTTPConnectionPool(host='127.0.0.1', port=3306): Max retries exceeded with url: /db/data/ (Caused by NewConnectionError('<requests.packages.urllib3.connection.HTTPConnection object at 0x7ff562077310>: Failed to establish a new connection: [Errno 111] Connection refused',))